### PR TITLE
move dependency versions to a shared location

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,11 @@
 buildscript {
-    ext.kotlin_version = '1.3.61'
+    ext.androidxAppCompatVersion = '1.1.0'
+    ext.androidxCoreVersion = '1.2.0'
+    ext.gradlePluginVersion = '3.6.0'
+    ext.kotlinVersion = '1.3.61'
     ext.ktlintVersion = '0.36.0'
     ext.ktlintGradlePluginVersion = '9.2.1'
+    ext.junitVersion = '4.12'
 
     repositories {
         google()
@@ -9,8 +13,8 @@ buildscript {
         maven { url 'https://plugins.gradle.org/m2/' }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.6.0'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+        classpath "com.android.tools.build:gradle:$gradlePluginVersion"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
 
         // Plugin for ktlint
         classpath "org.jlleitschuh.gradle:ktlint-gradle:$ktlintGradlePluginVersion"

--- a/overlapping_panels/build.gradle
+++ b/overlapping_panels/build.gradle
@@ -25,10 +25,9 @@ android {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation 'androidx.appcompat:appcompat:1.1.0'
-    implementation 'androidx.core:core-ktx:1.2.0'
-    testImplementation 'junit:junit:4.12'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.1'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlinVersion"
+    implementation "androidx.appcompat:appcompat:$androidxAppCompatVersion"
+    implementation "androidx.core:core-ktx:$androidxCoreVersion"
+
+    testImplementation "junit:junit:$junitVersion"
 }

--- a/sample_app/build.gradle
+++ b/sample_app/build.gradle
@@ -27,11 +27,10 @@ android {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation 'androidx.appcompat:appcompat:1.1.0'
-    implementation 'androidx.core:core-ktx:1.2.0'
-    implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
-    testImplementation 'junit:junit:4.12'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.1'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlinVersion"
+    implementation "androidx.appcompat:appcompat:$androidxAppCompatVersion"
+    implementation "androidx.core:core-ktx:$androidxCoreVersion"
+    implementation project(path: ':overlapping_panels')
+
+    testImplementation "junit:junit:$junitVersion"
 }


### PR DESCRIPTION
Move the dependency versions to a shared location instead of hardcoding the dependency versions for each individual module.