### PR TITLE
support max side panel width for tablets

### DIFF
--- a/overlapping_panels/src/main/res/values/attrs.xml
+++ b/overlapping_panels/src/main/res/values/attrs.xml
@@ -1,0 +1,12 @@
+<resources>
+    <declare-styleable name="OverlappingPanelsLayout">
+        <!--
+         The side panel width will be the minimum between (1) this maxSidePanelNonFullScreenWidth
+         and (2) the default side panel width determined by the portrait mode screen width
+         minus the margin between panels and the width of the visible closed center panel.
+         This is most useful for setting a side panel width on tablets.
+         This max width does not apply when useFullPortraitWidthForStartPanel is true.
+         -->
+        <attr name="maxSidePanelNonFullScreenWidth" format="dimension|reference" />
+    </declare-styleable>
+</resources>


### PR DESCRIPTION
For phones, we set the side panel width to the portrait screen width minus the visible width of the closed center panel minus the margin between panels.

That logic makes the side panels very wide on tablets, so this PR adds an attribute on `OverlappingPanelsLayout` to set a max non-full-screen width fro the side panel. `OverlappingPanelsLayout` will set the side panel width to the minimum between the portrait-screen-width based panel width and the max non-full-screen width.

The max non-full-screen width does not affect `OverlappingPanels#setStartPanelUseFullPortraitWidth()` API which still sets the start panel width to the full screen width.