### PR TITLE
clean up sample_app build.gradle

### DIFF
--- a/sample_app/build.gradle
+++ b/sample_app/build.gradle
@@ -31,7 +31,7 @@ dependencies {
     implementation "androidx.appcompat:appcompat:$androidxAppCompatVersion"
     implementation "androidx.core:core-ktx:$androidxCoreVersion"
     implementation "io.reactivex.rxjava3:rxjava:$rxJavaVersion"
-    implementation project(path: ':overlapping_panels')
+    implementation project(':overlapping_panels')
 
     testImplementation "junit:junit:$junitVersion"
 }


### PR DESCRIPTION
`path:` is unnecessary in `build.gradle` here, so we can delete it. The sample app builds and installs correctly without `path:`.