### PR TITLE
remove isLocked from PanelState

### DIFF
--- a/overlapping_panels/src/main/java/com/discord/panels/OverlappingPanelsLayout.kt
+++ b/overlapping_panels/src/main/java/com/discord/panels/OverlappingPanelsLayout.kt
@@ -417,13 +417,13 @@ open class OverlappingPanelsLayout : FrameLayout {
   fun handleStartPanelState(startPanelState: PanelState) {
     val previousStartPanelState = this.startPanelState
     when {
-      (startPanelState is PanelState.Opened &&
-          previousStartPanelState !is PanelState.Opened) -> {
+      (startPanelState == PanelState.Opened &&
+          previousStartPanelState != PanelState.Opened) -> {
         openStartPanel()
       }
 
-      (startPanelState is PanelState.Closed &&
-          previousStartPanelState is PanelState.Opened) -> {
+      (startPanelState == PanelState.Closed &&
+          previousStartPanelState == PanelState.Opened) -> {
         closePanels()
       }
     }
@@ -444,13 +444,13 @@ open class OverlappingPanelsLayout : FrameLayout {
     val previousEndPanelState = this.endPanelState
 
     when {
-      (endPanelState is PanelState.Opened &&
-          previousEndPanelState !is PanelState.Opened) -> {
+      (endPanelState == PanelState.Opened &&
+          previousEndPanelState != PanelState.Opened) -> {
         openEndPanel()
       }
 
       (endPanelState is PanelState.Closed &&
-          previousEndPanelState is PanelState.Opened) -> {
+          previousEndPanelState == PanelState.Opened) -> {
         closePanels()
       }
     }
@@ -764,11 +764,10 @@ open class OverlappingPanelsLayout : FrameLayout {
   }
 
   private fun getStartPanelState(previousX: Float, x: Float): PanelState {
-    val isLockedOpen = startPanelLockState == LockState.OPEN
     return when {
       isLeftToRight && x <= 0F -> PanelState.Closed
       !isLeftToRight && x >= 0f -> PanelState.Closed
-      x == startPanelOpenedCenterPanelX -> PanelState.Opened(isLocked = isLockedOpen)
+      x == startPanelOpenedCenterPanelX -> PanelState.Opened
       isLeftToRight && x > previousX -> PanelState.Opening
       !isLeftToRight && x < previousX -> PanelState.Opening
       else -> PanelState.Closing
@@ -776,11 +775,10 @@ open class OverlappingPanelsLayout : FrameLayout {
   }
 
   private fun getEndPanelState(previousX: Float, x: Float): PanelState {
-    val isLockedOpen = endPanelLockState == LockState.OPEN
     return when {
       isLeftToRight && x >= 0F -> PanelState.Closed
       !isLeftToRight && x <= 0f -> PanelState.Closed
-      x == endPanelOpenedCenterPanelX -> PanelState.Opened(isLocked = isLockedOpen)
+      x == endPanelOpenedCenterPanelX -> PanelState.Opened
       isLeftToRight && x < previousX -> PanelState.Opening
       !isLeftToRight && x > previousX -> PanelState.Opening
       else -> PanelState.Closing

--- a/overlapping_panels/src/main/java/com/discord/panels/PanelState.kt
+++ b/overlapping_panels/src/main/java/com/discord/panels/PanelState.kt
@@ -2,7 +2,7 @@ package com.discord.panels
 
 sealed class PanelState {
   object Opening : PanelState()
-  data class Opened(val isLocked: Boolean) : PanelState()
+  object Opened : PanelState()
   object Closing : PanelState()
   object Closed : PanelState()
 }

--- a/sample_app/src/test/java/com/discord/sampleapp/OverlappingPanelsIntegrationTest.kt
+++ b/sample_app/src/test/java/com/discord/sampleapp/OverlappingPanelsIntegrationTest.kt
@@ -69,11 +69,7 @@ class OverlappingPanelsIntegrationTest {
     dispatchSwipeRightGesture(overlappingPanelsLayout)
     runPendingAnimations()
 
-    Truth.assertThat(startPanelState).isEqualTo(
-      PanelState.Opened(
-        isLocked = false
-      )
-    )
+    Truth.assertThat(startPanelState).isEqualTo(PanelState.Opened)
 
     Truth.assertThat(endPanelState).isEqualTo(
       PanelState.Closed
@@ -106,11 +102,7 @@ class OverlappingPanelsIntegrationTest {
       PanelState.Closed
     )
 
-    Truth.assertThat(endPanelState).isEqualTo(
-      PanelState.Opened(
-        isLocked = false
-      )
-    )
+    Truth.assertThat(endPanelState).isEqualTo(PanelState.Opened)
   }
 
   @Test
@@ -127,7 +119,7 @@ class OverlappingPanelsIntegrationTest {
     overlappingPanelsLayout.openStartPanel()
     runPendingAnimations()
 
-    Truth.assertThat(startPanelState).isEqualTo(PanelState.Opened(isLocked = false))
+    Truth.assertThat(startPanelState).isEqualTo(PanelState.Opened)
   }
 
   @Test
@@ -144,7 +136,7 @@ class OverlappingPanelsIntegrationTest {
     overlappingPanelsLayout.openEndPanel()
     runPendingAnimations()
 
-    Truth.assertThat(endPanelState).isEqualTo(PanelState.Opened(isLocked = false))
+    Truth.assertThat(endPanelState).isEqualTo(PanelState.Opened)
   }
 
   @Test
@@ -168,7 +160,7 @@ class OverlappingPanelsIntegrationTest {
 
     overlappingPanelsLayout.openStartPanel()
     runPendingAnimations()
-    Truth.assertThat(startPanelState).isEqualTo(PanelState.Opened(isLocked = false))
+    Truth.assertThat(startPanelState).isEqualTo(PanelState.Opened)
     Truth.assertThat(endPanelState).isEqualTo(PanelState.Closed)
 
     overlappingPanelsLayout.closePanels()


### PR DESCRIPTION
`PanelState.Opened` used to have an `isLocked` field which Discord's Android app used when it was sharing `PanelState` across both `OverlappingPanelsLayout` and Android's stock `DrawerLayout`. Only Discord's `DrawerLayout` state management needed `isLocked`. Moving forward, `PanelState` should only be used with `OverlappingPanelsLayout`. `PanelState` is no longer intended for use with `DrawerLayout`, so this PR removes the `isLocked` field.