### PR TITLE
don't treat available dependency upgrades as errors

### DIFF
--- a/tools/lint.xml
+++ b/tools/lint.xml
@@ -1,4 +1,7 @@
 <lint>
     <!-- Not supported by Overlapping Panels at the moment. -->
     <issue id="ClickableViewAccessibility" severity="ignore" />
+
+    <!-- Don't error when there is a newer version of a gradle dependency available. -->
+    <issue id="GradleDependency" severity="informational" />
 </lint>


### PR DESCRIPTION
Lint tests were failing because there's a newer AndroidX version available: https://travis-ci.org/github/discord/OverlappingPanels/builds/715238115 . This PR updates our lint configuration to not treat available dependency upgrades as errors.