### PR TITLE
Fix closed center panel click detection

### DIFF
--- a/overlapping_panels/src/main/java/com/discord/panels/OverlappingPanelsLayout.kt
+++ b/overlapping_panels/src/main/java/com/discord/panels/OverlappingPanelsLayout.kt
@@ -7,7 +7,6 @@ import android.graphics.Rect
 import android.os.Build
 import android.text.TextUtils
 import android.util.AttributeSet
-import android.util.Log
 import android.view.MotionEvent
 import android.view.VelocityTracker
 import android.view.View
@@ -130,7 +129,6 @@ open class OverlappingPanelsLayout : FrameLayout {
   }
 
   private fun initialize(attrs: AttributeSet?) {
-    Log.d("pikachu", "initialize")
     val locale = LocaleProvider.getPrimaryLocale(context)
     isLeftToRight = TextUtils.getLayoutDirectionFromLocale(locale) == View.LAYOUT_DIRECTION_LTR
     scrollingSlopPx = resources.getDimension(R.dimen.overlapping_panels_scroll_slop)
@@ -167,11 +165,6 @@ open class OverlappingPanelsLayout : FrameLayout {
           Int.MAX_VALUE.toFloat()
         ).toInt()
 
-      Log.d("pikachu", """
-        nonFullScreenSidePanelWidth: $nonFullScreenSidePanelWidth
-        maxSidePanelNonFullScreenWidth: $maxSidePanelNonFullScreenWidth
-      """.trimIndent())
-
       nonFullScreenSidePanelWidth = min(nonFullScreenSidePanelWidth, maxSidePanelNonFullScreenWidth)
     } finally {
       styledAttrs.recycle()
@@ -201,7 +194,6 @@ open class OverlappingPanelsLayout : FrameLayout {
       MotionEvent.ACTION_DOWN -> {
         isScrollingHorizontally = false
         wasActionDownOnClosedCenterPanel = isTouchingCenterPanelWhileSidePanelOpen(event)
-        Log.d("pikachu", "wasActionDownOnClosedCenterPanel: $wasActionDownOnClosedCenterPanel")
         centerPanelDiffX = centerPanel.x - event.rawX
 
         xFromInterceptActionDown = event.x
@@ -803,7 +795,6 @@ open class OverlappingPanelsLayout : FrameLayout {
   }
 
   private fun initPanels() {
-    Log.d("pikachu", "initPanels")
     startPanel = getChildAt(0)
     centerPanel = getChildAt(1)
     endPanel = getChildAt(2)
@@ -836,12 +827,9 @@ open class OverlappingPanelsLayout : FrameLayout {
     // user and then becomes non-full-screen after the user has channels or guilds), then
     // recalculate the min and max x values.
     startPanel.addOnLayoutChangeListener { _, left, _, right, _, oldLeft, _, oldRight, _ ->
-      Log.d("pikachu", "start panel on layout change. width: ${right - left}")
       if (isLeftToRight && right != oldRight) {
-        Log.d("pikachu", "start panel width changed 000")
         handleStartPanelWidthUpdate()
       } else if (!isLeftToRight && left != oldLeft) {
-        Log.d("pikachu", "start panel width changed 111")
         handleStartPanelWidthUpdate()
       }
     }
@@ -855,24 +843,16 @@ open class OverlappingPanelsLayout : FrameLayout {
   }
 
   private fun isTouchingCenterPanelWhileSidePanelOpen(event: MotionEvent): Boolean {
-    val rawX = event.rawX
+    val x = event.x
     val centerPanelX = centerPanel.x
-
-    Log.d("pikachu", """
-      isTouchingCenterPanelWhileSidePanelOpen
-      startPanelOpenedCenterPanelX: $startPanelOpenedCenterPanelX
-      endPanelOpenedCenterPanelX: $endPanelOpenedCenterPanelX
-      rawX: $rawX
-      centerPanelX: $centerPanelX
-    """.trimIndent())
 
     val maxCenterPanelX = max(startPanelOpenedCenterPanelX, endPanelOpenedCenterPanelX)
     val minCenterPanelX = min(startPanelOpenedCenterPanelX, endPanelOpenedCenterPanelX)
     val centerPanelRightEdgeXWhenRightPanelFullyOpen = minCenterPanelX + centerPanel.width
 
-    val isTouchingCenterPanelWithLeftPanelOpen = rawX > maxCenterPanelX
+    val isTouchingCenterPanelWithLeftPanelOpen = x > maxCenterPanelX
     val isTouchingCenterPanelWithRightPanelOpen =
-      rawX < centerPanelRightEdgeXWhenRightPanelFullyOpen
+      x < centerPanelRightEdgeXWhenRightPanelFullyOpen
     val isLeftPanelFullyOpen = centerPanelX == maxCenterPanelX
     val isRightPanelFullyOpen = centerPanelX == minCenterPanelX
 
@@ -906,13 +886,6 @@ open class OverlappingPanelsLayout : FrameLayout {
     val previousStartPanelOpenedCenterPanelX = startPanelOpenedCenterPanelX
     val marginBetweenPanels =
       resources.getDimension(R.dimen.overlapping_panels_margin_between_panels)
-
-    Log.d("pikachu", """
-      handleStartPanelWidthUpdate
-      start panel width: ${startPanel.width}
-      marginBetweenPanels: $marginBetweenPanels
-      density: ${resources.displayMetrics.density}
-    """.trimIndent())
 
     startPanelOpenedCenterPanelX = startPanel.width + marginBetweenPanels
     startPanelOpenedCenterPanelX =

--- a/overlapping_panels/src/main/java/com/discord/panels/OverlappingPanelsLayout.kt
+++ b/overlapping_panels/src/main/java/com/discord/panels/OverlappingPanelsLayout.kt
@@ -7,6 +7,7 @@ import android.graphics.Rect
 import android.os.Build
 import android.text.TextUtils
 import android.util.AttributeSet
+import android.util.Log
 import android.view.MotionEvent
 import android.view.VelocityTracker
 import android.view.View
@@ -129,6 +130,7 @@ open class OverlappingPanelsLayout : FrameLayout {
   }
 
   private fun initialize(attrs: AttributeSet?) {
+    Log.d("pikachu", "initialize")
     val locale = LocaleProvider.getPrimaryLocale(context)
     isLeftToRight = TextUtils.getLayoutDirectionFromLocale(locale) == View.LAYOUT_DIRECTION_LTR
     scrollingSlopPx = resources.getDimension(R.dimen.overlapping_panels_scroll_slop)
@@ -165,6 +167,11 @@ open class OverlappingPanelsLayout : FrameLayout {
           Int.MAX_VALUE.toFloat()
         ).toInt()
 
+      Log.d("pikachu", """
+        nonFullScreenSidePanelWidth: $nonFullScreenSidePanelWidth
+        maxSidePanelNonFullScreenWidth: $maxSidePanelNonFullScreenWidth
+      """.trimIndent())
+
       nonFullScreenSidePanelWidth = min(nonFullScreenSidePanelWidth, maxSidePanelNonFullScreenWidth)
     } finally {
       styledAttrs.recycle()
@@ -194,6 +201,7 @@ open class OverlappingPanelsLayout : FrameLayout {
       MotionEvent.ACTION_DOWN -> {
         isScrollingHorizontally = false
         wasActionDownOnClosedCenterPanel = isTouchingCenterPanelWhileSidePanelOpen(event)
+        Log.d("pikachu", "wasActionDownOnClosedCenterPanel: $wasActionDownOnClosedCenterPanel")
         centerPanelDiffX = centerPanel.x - event.rawX
 
         xFromInterceptActionDown = event.x
@@ -795,6 +803,7 @@ open class OverlappingPanelsLayout : FrameLayout {
   }
 
   private fun initPanels() {
+    Log.d("pikachu", "initPanels")
     startPanel = getChildAt(0)
     centerPanel = getChildAt(1)
     endPanel = getChildAt(2)
@@ -827,9 +836,12 @@ open class OverlappingPanelsLayout : FrameLayout {
     // user and then becomes non-full-screen after the user has channels or guilds), then
     // recalculate the min and max x values.
     startPanel.addOnLayoutChangeListener { _, left, _, right, _, oldLeft, _, oldRight, _ ->
+      Log.d("pikachu", "start panel on layout change. width: ${right - left}")
       if (isLeftToRight && right != oldRight) {
+        Log.d("pikachu", "start panel width changed 000")
         handleStartPanelWidthUpdate()
       } else if (!isLeftToRight && left != oldLeft) {
+        Log.d("pikachu", "start panel width changed 111")
         handleStartPanelWidthUpdate()
       }
     }
@@ -845,6 +857,14 @@ open class OverlappingPanelsLayout : FrameLayout {
   private fun isTouchingCenterPanelWhileSidePanelOpen(event: MotionEvent): Boolean {
     val rawX = event.rawX
     val centerPanelX = centerPanel.x
+
+    Log.d("pikachu", """
+      isTouchingCenterPanelWhileSidePanelOpen
+      startPanelOpenedCenterPanelX: $startPanelOpenedCenterPanelX
+      endPanelOpenedCenterPanelX: $endPanelOpenedCenterPanelX
+      rawX: $rawX
+      centerPanelX: $centerPanelX
+    """.trimIndent())
 
     val maxCenterPanelX = max(startPanelOpenedCenterPanelX, endPanelOpenedCenterPanelX)
     val minCenterPanelX = min(startPanelOpenedCenterPanelX, endPanelOpenedCenterPanelX)
@@ -886,6 +906,14 @@ open class OverlappingPanelsLayout : FrameLayout {
     val previousStartPanelOpenedCenterPanelX = startPanelOpenedCenterPanelX
     val marginBetweenPanels =
       resources.getDimension(R.dimen.overlapping_panels_margin_between_panels)
+
+    Log.d("pikachu", """
+      handleStartPanelWidthUpdate
+      start panel width: ${startPanel.width}
+      marginBetweenPanels: $marginBetweenPanels
+      density: ${resources.displayMetrics.density}
+    """.trimIndent())
+
     startPanelOpenedCenterPanelX = startPanel.width + marginBetweenPanels
     startPanelOpenedCenterPanelX =
       if (isLeftToRight) startPanelOpenedCenterPanelX else -startPanelOpenedCenterPanelX

--- a/overlapping_panels/src/main/java/com/discord/panels/OverlappingPanelsLayout.kt
+++ b/overlapping_panels/src/main/java/com/discord/panels/OverlappingPanelsLayout.kt
@@ -886,7 +886,6 @@ open class OverlappingPanelsLayout : FrameLayout {
     val previousStartPanelOpenedCenterPanelX = startPanelOpenedCenterPanelX
     val marginBetweenPanels =
       resources.getDimension(R.dimen.overlapping_panels_margin_between_panels)
-
     startPanelOpenedCenterPanelX = startPanel.width + marginBetweenPanels
     startPanelOpenedCenterPanelX =
       if (isLeftToRight) startPanelOpenedCenterPanelX else -startPanelOpenedCenterPanelX

--- a/sample_app/src/main/java/com/discord/sampleapp/MainActivity.kt
+++ b/sample_app/src/main/java/com/discord/sampleapp/MainActivity.kt
@@ -1,14 +1,16 @@
 package com.discord.sampleapp
 
 import android.graphics.Rect
-import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
 import android.view.View
+import android.widget.Toast
+import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.ViewModelProvider
 import com.discord.panels.OverlappingPanelsLayout
 import com.discord.panels.PanelState
 import com.discord.panels.PanelsChildGestureRegionObserver
 import io.reactivex.rxjava3.disposables.Disposable
+
 
 class MainActivity : AppCompatActivity(),
   PanelsChildGestureRegionObserver.GestureRegionsListener {
@@ -19,6 +21,7 @@ class MainActivity : AppCompatActivity(),
   private lateinit var overlappingPanels: OverlappingPanelsLayout
   private lateinit var openStartPanelButton: View
   private lateinit var horizontalScrollItemsContainer: View
+  private lateinit var showToastButton: View
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
@@ -50,6 +53,15 @@ class MainActivity : AppCompatActivity(),
     horizontalScrollItemsContainer.addOnLayoutChangeListener(
       PanelsChildGestureRegionObserver.Provider.get()
     )
+
+    showToastButton = findViewById(R.id.show_toast_button)
+    showToastButton.setOnClickListener {
+      Toast.makeText(
+        this,
+        "clicked button in start panel",
+        Toast.LENGTH_LONG
+      ).show()
+    }
 
     viewModel = ViewModelProvider(
       this,

--- a/sample_app/src/main/java/com/discord/sampleapp/MainActivity.kt
+++ b/sample_app/src/main/java/com/discord/sampleapp/MainActivity.kt
@@ -11,7 +11,6 @@ import com.discord.panels.PanelState
 import com.discord.panels.PanelsChildGestureRegionObserver
 import io.reactivex.rxjava3.disposables.Disposable
 
-
 class MainActivity : AppCompatActivity(),
   PanelsChildGestureRegionObserver.GestureRegionsListener {
 
@@ -54,6 +53,8 @@ class MainActivity : AppCompatActivity(),
       PanelsChildGestureRegionObserver.Provider.get()
     )
 
+    // This button helps verify the accuracy of
+    // OverlappingPanelsLayout#isTouchingCenterPanelWhileSidePanelOpen()
     showToastButton = findViewById(R.id.show_toast_button)
     showToastButton.setOnClickListener {
       Toast.makeText(

--- a/sample_app/src/main/res/layout/main_activity.xml
+++ b/sample_app/src/main/res/layout/main_activity.xml
@@ -22,24 +22,23 @@
         <LinearLayout
             android:id="@+id/start_panel"
             style="@style/Panel"
-            android:paddingEnd="0dp"
             android:layout_width="wrap_content"
             android:layout_height="match_parent"
             android:layout_gravity="start"
-            android:orientation="vertical">
+            android:orientation="vertical"
+            android:paddingEnd="0dp">
 
             <TextView
                 style="@style/PanelHeader"
                 android:text="@string/start_panel_name" />
 
             <Button
-                android:layout_marginTop="16dp"
-                android:layout_height="wrap_content"
-                android:layout_width="wrap_content"
                 android:id="@+id/show_toast_button"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
                 android:layout_gravity="end"
+                android:layout_marginTop="16dp"
                 android:text="show toast" />
-
 
         </LinearLayout>
 

--- a/sample_app/src/main/res/layout/main_activity.xml
+++ b/sample_app/src/main/res/layout/main_activity.xml
@@ -26,6 +26,7 @@
             android:layout_height="match_parent"
             android:layout_gravity="start"
             android:orientation="vertical"
+            android:paddingStart="16dp"
             android:paddingEnd="0dp">
 
             <TextView
@@ -38,7 +39,7 @@
                 android:layout_height="wrap_content"
                 android:layout_gravity="end"
                 android:layout_marginTop="16dp"
-                android:text="show toast" />
+                android:text="@string/show_toast" />
 
         </LinearLayout>
 

--- a/sample_app/src/main/res/layout/main_activity.xml
+++ b/sample_app/src/main/res/layout/main_activity.xml
@@ -17,8 +17,7 @@
         android:id="@+id/overlapping_panels"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:background="@color/light_grey"
-        app:maxSidePanelNonFullScreenWidth="360dp">
+        android:background="@color/light_grey">
 
         <LinearLayout
             android:id="@+id/start_panel"

--- a/sample_app/src/main/res/layout/main_activity.xml
+++ b/sample_app/src/main/res/layout/main_activity.xml
@@ -17,11 +17,13 @@
         android:id="@+id/overlapping_panels"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:background="@color/light_grey">
+        android:background="@color/light_grey"
+        app:maxSidePanelNonFullScreenWidth="360dp">
 
         <LinearLayout
             android:id="@+id/start_panel"
             style="@style/Panel"
+            android:paddingEnd="0dp"
             android:layout_width="wrap_content"
             android:layout_height="match_parent"
             android:layout_gravity="start"
@@ -30,6 +32,15 @@
             <TextView
                 style="@style/PanelHeader"
                 android:text="@string/start_panel_name" />
+
+            <Button
+                android:layout_marginTop="16dp"
+                android:layout_height="wrap_content"
+                android:layout_width="wrap_content"
+                android:id="@+id/show_toast_button"
+                android:layout_gravity="end"
+                android:text="show toast" />
+
 
         </LinearLayout>
 

--- a/sample_app/src/main/res/values/strings.xml
+++ b/sample_app/src/main/res/values/strings.xml
@@ -12,4 +12,5 @@
     <string name="scroll_item_3">scroll item 3</string>
     <string name="scroll_item_4">scroll item 4</string>
     <string name="scroll_item_5">scroll item 5</string>
+    <string name="show_toast">show toast</string>
 </resources>


### PR DESCRIPTION
This PR fixes a bug where in landscape mode on a device with a display cutout (e.g. a Samsung S10), clicking the right edge of the opened left panel gets handled incorrectly as clicking the closed center panel.

**Steps to reproduce the bug**
1) Install the sample app with the changes in this PR on a device with a display cutout
2) Rotate the device to landscape mode.
3) Click the right edge of the "show toast" button

**Buggy behavior before this PR**
The click gets handled as clicking the closed center panel


https://user-images.githubusercontent.com/3821698/106031575-4b49a800-6084-11eb-92a3-acf5ed2fdf12.mp4


**Expected behavior after this PR**
The click gets handled as clicking the button, so you see the toast.


https://user-images.githubusercontent.com/3821698/106031586-4edd2f00-6084-11eb-8ca8-25cce13b3903.mp4

Using the debug logs in https://github.com/discord/OverlappingPanels/pull/20/commits/ca3a4fba0132b949be670b2e175b433309bf2016 , I observed the following values in `isTouchingCenterPanelWhileSidePanelOpen`.
![Screen Shot 2021-01-27 at 9 32 02 AM](https://user-images.githubusercontent.com/3821698/106031742-746a3880-6084-11eb-9e6f-789c5263dea8.png) . That method tries to detect if the touch event is to the right of the left edge of the center panel. If so, it considers the click event a click on the closed center panel. However, I saw that the `rawX` was at 1016px while the right edge of the start panel was at 954px even though I clicked to the left of the center panel. I realized the `rawX` was greater than it should've been because it included the width of the display cutout which was not included in the start panel width. To fix this, I changed `event.rawX` to `event.x`. Now we consider the click event relative to the coordinates in the `OverlappingPanelsLayout` view when calculating `isTouchingCenterPanelWhileSidePanelOpen`.
