### PR TITLE
delete deprecated child gesture region APIs

### DIFF
--- a/overlapping_panels/src/main/java/com/discord/panels/PanelsChildGestureRegionObserver.kt
+++ b/overlapping_panels/src/main/java/com/discord/panels/PanelsChildGestureRegionObserver.kt
@@ -1,6 +1,7 @@
 package com.discord.panels
 
 import android.graphics.Rect
+import android.util.Log
 import android.view.View
 import android.view.ViewTreeObserver
 import androidx.annotation.UiThread
@@ -69,9 +70,11 @@ class PanelsChildGestureRegionObserver : View.OnLayoutChangeListener {
   @UiThread
   fun register(view: View) {
     if (viewIdToListenerMap.contains(view.id)) {
-
-      // Remove the old listeners before adding new ones.
-      unregister(view)
+      Log.w(
+        javaClass.simpleName,
+        "failed to register view with ID ${view.id}. already registered"
+      )
+      return
     }
 
     view.addOnLayoutChangeListener(this)

--- a/overlapping_panels/src/main/java/com/discord/panels/PanelsChildGestureRegionObserver.kt
+++ b/overlapping_panels/src/main/java/com/discord/panels/PanelsChildGestureRegionObserver.kt
@@ -16,14 +16,13 @@ import java.lang.ref.WeakReference
  * Example usage:
  * 1) Use [PanelsChildGestureRegionObserver.Provider.get] to get an Activity-scoped instance of
  * [PanelsChildGestureRegionObserver]
- * 2) Add the [PanelsChildGestureRegionObserver] instance as an android.view.OnLayoutChangeListener
- * to each child view.
+ * 2) Register the child gesture region View with the [register].
  * 3) In the parent of [OverlappingPanelsLayout], e.g. in a Fragment or Activity, implement
  * [GestureRegionsListener], and add the listener via [addGestureRegionsUpdateListener]
  * 4) Inside [GestureRegionsListener.onGestureRegionsUpdate], pass the child gesture regions to
  * [OverlappingPanelsLayout].
- * 5) Remember to remove views and listeners from [PanelsChildGestureRegionObserver] with [remove]
- * and [removeGestureRegionsUpdateListener] in appropriate Android lifecycle methods.
+ * 5) Remember to unregister the child gesture region with [unregister] in appropriate Android
+ * lifecycle methods.
  */
 class PanelsChildGestureRegionObserver : View.OnLayoutChangeListener {
 
@@ -71,11 +70,9 @@ class PanelsChildGestureRegionObserver : View.OnLayoutChangeListener {
   @UiThread
   fun register(view: View) {
     if (viewIdToListenerMap.contains(view.id)) {
-      Log.w(
-        javaClass.simpleName,
-        "failed to register view with ID ${view.id}. already registered"
-      )
-      return
+
+      // Remove the old listeners before adding new ones.
+      unregister(view)
     }
 
     view.addOnLayoutChangeListener(this)
@@ -96,20 +93,6 @@ class PanelsChildGestureRegionObserver : View.OnLayoutChangeListener {
 
     view.viewTreeObserver.addOnScrollChangedListener(listener)
     viewIdToListenerMap[view.id] = listener
-  }
-
-  /**
-   * Stop publishing gesture region updates based on layout changes to android.view.View
-   * corresponding to [viewId].
-   */
-  @Deprecated(
-    message = "Use unregister instead",
-    replaceWith = ReplaceWith("unregister(view)")
-  )
-  @UiThread
-  fun remove(viewId: Int) {
-    viewIdToGestureRegionMap.remove(viewId)
-    publishGestureRegionsUpdate()
   }
 
   /**

--- a/overlapping_panels/src/main/java/com/discord/panels/PanelsChildGestureRegionObserver.kt
+++ b/overlapping_panels/src/main/java/com/discord/panels/PanelsChildGestureRegionObserver.kt
@@ -1,7 +1,6 @@
 package com.discord.panels
 
 import android.graphics.Rect
-import android.util.Log
 import android.view.View
 import android.view.ViewTreeObserver
 import androidx.annotation.UiThread

--- a/sample_app/src/main/java/com/discord/sampleapp/MainActivity.kt
+++ b/sample_app/src/main/java/com/discord/sampleapp/MainActivity.kt
@@ -60,13 +60,12 @@ class MainActivity : AppCompatActivity(),
 
     // To not handle panel gestures on selected child views, e.g. if the child view has its own
     // horizontal scroll handling,
-    // 1) Add PanelsChildGestureRegionObserver as an OnLayoutChangeListener on that child view
+    // 1) Register the child view as a gesture region.
     // 2) Make the host fragment / activity listen to child gesture region updates (e.g. in
     //    onResume()).
-    // 3) Remember to remove the listener (e.g. in onPause() for an Activity), and remove the
-    //    child view from PanelsChildGestureRegionObserver.
+    // 3) Remember to unregister the region (e.g. in onPause() for an Activity).
     //
-    // In this example, we're adding the OnLayoutChangeListener to a view in main_activity.xml.
+    // In this example, we're registering a view in main_activity.xml.
     // This will also work in other cases like child views in Fragments within MainActivity
     // because PanelsChildGestureRegionObserver.Provider.get() returns an Activity-scoped
     // singleton.
@@ -95,7 +94,7 @@ class MainActivity : AppCompatActivity(),
 
     viewPager.apply {
       adapter = this@MainActivity.adapter
-      addOnLayoutChangeListener(PanelsChildGestureRegionObserver.Provider.get())
+      PanelsChildGestureRegionObserver.Provider.get().register(this)
     }
 
     TabLayoutMediator(tabLayout, viewPager) { tab, position ->
@@ -103,7 +102,7 @@ class MainActivity : AppCompatActivity(),
     }.attach()
 
     tabLayout.apply {
-      addOnLayoutChangeListener(PanelsChildGestureRegionObserver.Provider.get())
+      PanelsChildGestureRegionObserver.Provider.get().register(tabLayout)
     }
   }
 


### PR DESCRIPTION
# Description

Our bug fix in https://github.com/discord/OverlappingPanels/pull/31 broke the deprecated child-gesture-region APIs that required directly calling `View#addOnLayoutChangeListener` and `PanelsChildGestureRegionObserver#remove()`. This PR deletes those deprecated APIs and updates documentation. Moving forward, we should use `PanelsChildGestureRegionObserver#register()` and `PanelsChildGestureRegionObserver#unregister()`.


# Test Plan

Run these changes in the sample app. Confirm that horizontal scrolling in the main center panel works, and confirm that horizontal scrolling in the view pager works.